### PR TITLE
fix BGE/RET bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+vivado_proj/

--- a/source/IMem_IW.sv
+++ b/source/IMem_IW.sv
@@ -2,9 +2,6 @@
 	Name: Pipeline register between Memory Access and WriteBack Stage
 */
 
-
-
-
 module IMem_IW (input logic clk, reset,
                 input logic [31:0] ALUResultM, ReadDataM,  
                 input logic [4:0] RdM, 

--- a/source/adder.sv
+++ b/source/adder.sv
@@ -1,3 +1,5 @@
 module adder(input [31:0] a, b, output [31:0] y);
+
 	assign y = $signed(a) + $signed(b);
+	
 endmodule

--- a/source/alu.sv
+++ b/source/alu.sv
@@ -4,7 +4,6 @@
 	Description: Receives control signals from the ALU Decoder and performs the operations
 */
 
-
 module alu(input logic [31:0] SrcA, 
 			input logic [31:0] SrcB, 
 			input logic [3:0] ALUControl , 
@@ -23,7 +22,7 @@ assign Sign = ALUResult[31];
 
 always_comb
 		casex (ALUControl)
-				4'b000x: ALUResult = Sum;				// sum or diff
+				4'b000x: ALUResult = Sum;			// sum or diff
 				4'b0010: ALUResult = SrcA & SrcB;	// and
 				4'b0011: ALUResult = SrcA | SrcB;	// or
 				4'b0100: ALUResult = SrcA << SrcB;	// sll, slli
@@ -35,7 +34,5 @@ always_comb
 				default: ALUResult = 32'bx;
 		endcase
 
-
 endmodule
-		
 	

--- a/source/c_ID_IEx.sv
+++ b/source/c_ID_IEx.sv
@@ -1,54 +1,65 @@
 /*
-	Name: Control Unit Pipeline Register between Decode and Execution Stage*/
+    Name: Control Unit Pipeline Register between Decode and Execution Stage
+*/
 
-
-
-module c_ID_IEx (input logic clk, reset, clear,
-        input logic RegWriteD, MemWriteD, JumpD, BranchD, ALUSrcAD,
-		input logic [1:0] ALUSrcBD,
-        input logic [1:0] ResultSrcD, 
-        input logic [3:0] ALUControlD,  
-        output logic RegWriteE, MemWriteE, JumpE, BranchE,  ALUSrcAE,
-		output logic [1:0] ALUSrcBE,
-        output logic [1:0] ResultSrcE,
-        output logic [3:0] ALUControlE);
+module c_ID_IEx (
+    input logic clk, reset, clear,
+    input logic RegWriteD, MemWriteD, JumpD, BranchD, ALUSrcAD,
+    input logic [1:0] ALUSrcBD,
+    input logic [1:0] ResultSrcD, 
+    input logic [3:0] ALUControlD,
+    input logic [2:0] funct3D,
+    input logic [6:0] opD,
+    output logic RegWriteE, MemWriteE, JumpE, BranchE,  ALUSrcAE,
+    output logic [1:0] ALUSrcBE,
+    output logic [1:0] ResultSrcE,
+    output logic [3:0] ALUControlE,
+    output logic [2:0] funct3E,
+    output logic [6:0] opE
+);
 
 always_ff @( posedge clk, posedge reset ) begin
 
-		if (reset) begin
-			RegWriteE <= 0;
-			MemWriteE <= 0;
-			JumpE <= 0;
-			BranchE <= 0; 
-			ALUSrcAE <= 0;
-			ALUSrcBE <= 0;
-			ResultSrcE <= 0;
-			ALUControlE <= 0;          
-		end
+        if (reset) begin
+            RegWriteE <= 0;
+            MemWriteE <= 0;
+            JumpE <= 0;
+            BranchE <= 0; 
+            ALUSrcAE <= 0;
+            ALUSrcBE <= 0;
+            ResultSrcE <= 0;
+            ALUControlE <= 0;  
+            funct3E <= 0; 
+            opE <= 0;       
+        end
 
-		else if (clear) begin
-			RegWriteE <= 0;
-			MemWriteE <= 0;
-			JumpE <= 0;
-			BranchE <= 0; 
-			ALUSrcAE <= 0;
-			ALUSrcBE <= 0;
-			ResultSrcE <= 0;
-			ALUControlE <= 0;    			
-		end
-		
-		else begin
-			RegWriteE <= RegWriteD;
-			MemWriteE <= MemWriteD;
-			JumpE <= JumpD;
-			BranchE <= BranchD; 
-			ALUSrcAE <= ALUSrcAD;
-			ALUSrcBE <= ALUSrcBD;
-			ResultSrcE <= ResultSrcD;
-			ALUControlE <= ALUControlD;   
-		end
-		 
-	 end
+        else if (clear) begin
+            RegWriteE <= 0;
+            MemWriteE <= 0;
+            JumpE <= 0;
+            BranchE <= 0; 
+            ALUSrcAE <= 0;
+            ALUSrcBE <= 0;
+            ResultSrcE <= 0;
+            ALUControlE <= 0;
+            funct3E <= 0;
+            opE <= 0;  	
+        end
+        
+        else begin
+            RegWriteE <= RegWriteD;
+            MemWriteE <= MemWriteD;
+            JumpE <= JumpD;
+            BranchE <= BranchD; 
+            ALUSrcAE <= ALUSrcAD;
+            ALUSrcBE <= ALUSrcBD;
+            ResultSrcE <= ResultSrcD;
+            ALUControlE <= ALUControlD;   
+            funct3E <= funct3D;
+            opE <= opD;
+        end
+         
+     end
   
 endmodule
 

--- a/source/controller.sv
+++ b/source/controller.sv
@@ -1,59 +1,74 @@
 /*
-	Name: Controller or Control Unit
-	Description: 5 stage pipelined Control Unit
+    Name: Controller or Control Unit
+    Description: 5 stage pipelined Control Unit
 */
 
-
-
-
 module controller(input logic clk, reset,
-						input logic [6:0] op,
-						input logic [2:0] funct3,
-						input logic funct7b5,
-						input logic ZeroE,
-						input logic SignE,
-						input logic FlushE,
-						output logic ResultSrcE0,
-						output logic [1:0] ResultSrcW,
-						output logic MemWriteM,
-						output logic PCJalSrcE, PCSrcE, ALUSrcAE, 
-						output logic [1:0] ALUSrcBE,
-						output logic RegWriteM, RegWriteW,
-						output logic [2:0] ImmSrcD,
-						output logic [3:0] ALUControlE);
+                        input logic [6:0] op,
+                        input logic [2:0] funct3,
+                        input logic funct7b5,
+                        input logic ZeroE,
+                        input logic SignE,
+                        input logic FlushE,
+                        output logic ResultSrcE0,
+                        output logic [1:0] ResultSrcW,
+                        output logic MemWriteM,
+                        output logic PCJalSrcE, PCSrcE, ALUSrcAE, 
+                        output logic [1:0] ALUSrcBE,
+                        output logic RegWriteM, RegWriteW,
+                        output logic [2:0] ImmSrcD,
+                        output logic [3:0] ALUControlE);
 
 logic [1:0] ALUOpD;
 logic [1:0] ResultSrcD, ResultSrcE, ResultSrcM;
 logic [3:0] ALUControlD;
 logic BranchD, BranchE, MemWriteD, MemWriteE, JumpD, JumpE;
-logic ZeroOp, ALUSrcAD, RegWriteD, RegWriteE;
+logic ALUSrcAD, RegWriteD, RegWriteE;
 logic [1:0] ALUSrcBD;
-logic SignOp;
-logic BranchOp;
+logic ZeroOpE, SignOpE, BranchOpE;
+logic [2:0] funct3D,funct3E;
+logic [6:0] opD, opE;
+
+assign funct3D = funct3;
+assign opD = op;
 
 // main decoder
-maindec md(op, ResultSrcD, MemWriteD, BranchD, ALUSrcAD, ALUSrcBD, RegWriteD, JumpD, ImmSrcD, ALUOpD);
+maindec u_maindec(
+    .op       (op        ),
+    .ResultSrc(ResultSrcD),
+    .MemWrite (MemWriteD ),
+    .Branch   (BranchD   ),
+    .ALUSrcA  (ALUSrcAD  ),
+    .ALUSrcB  (ALUSrcBD  ),
+    .RegWrite (RegWriteD ),
+    .Jump     (JumpD     ),
+    .ImmSrc   (ImmSrcD   ),
+    .ALUOp	  (ALUOpD    )
+);
 
 // alu decoder
 aludec ad(op[5], funct3, funct7b5, ALUOpD, ALUControlD);
 
-
-c_ID_IEx c_pipreg0(clk, reset, FlushE, RegWriteD, MemWriteD, JumpD, BranchD, ALUSrcAD, ALUSrcBD, ResultSrcD, ALUControlD, 
-										RegWriteE, MemWriteE, JumpE, BranchE, ALUSrcAE, ALUSrcBE, ResultSrcE, ALUControlE);
+c_ID_IEx c_pipreg0(clk, reset, FlushE, 
+    RegWriteD, MemWriteD, JumpD, BranchD, ALUSrcAD, ALUSrcBD, ResultSrcD, ALUControlD, funct3D, opD,
+    RegWriteE, MemWriteE, JumpE, BranchE, ALUSrcAE, ALUSrcBE, ResultSrcE, ALUControlE, funct3E, opE
+);
 assign ResultSrcE0 = ResultSrcE[0];
 
-c_IEx_IM c_pipreg1(clk, reset, RegWriteE, MemWriteE, ResultSrcE, RegWriteM,  MemWriteM, ResultSrcM);
+c_IEx_IM c_pipreg1(clk, reset, 
+    RegWriteE, MemWriteE, ResultSrcE, 
+    RegWriteM, MemWriteM, ResultSrcM
+);
+c_IM_IW c_pipreg2 (clk, reset, 
+    RegWriteM, ResultSrcM, 
+    RegWriteW, ResultSrcW
+);
 
-c_IM_IW c_pipreg2 (clk, reset, RegWriteM, ResultSrcM, RegWriteW, ResultSrcW);
-
-
-assign ZeroOp = ZeroE ^ funct3[0]; // Complements Zero flag for BNE Instruction
-assign SignOp = (SignE ^ funct3[0]) ; //Complements Sign for BGE
-
-//mux2 BranchSrc (ZeroOp, SignOp, funct3[2], BranchOp); // fix this later
-assign BranchOp = funct3[2] ? (SignOp) : (ZeroOp); 
-assign PCSrcE = (BranchE & BranchOp) | JumpE;
-assign PCJalSrcE = (op == 7'b1100111) ? 1 : 0; // jalr
-
+// Branch Insts
+assign ZeroOpE = ZeroE ^ funct3E[0]; // Complements Zero flag for BNE Instruction
+assign SignOpE = (SignE ^ funct3E[0]) ; // Complements Sign for BGE
+assign BranchOpE = funct3E[2] ? (SignOpE) : (ZeroOpE);
+assign PCSrcE = (BranchE & BranchOpE) | JumpE;
+assign PCJalSrcE = (opE == 7'b1100111) ? 1 : 0; // jalr
 
 endmodule

--- a/source/datapath.sv
+++ b/source/datapath.sv
@@ -1,78 +1,66 @@
 /*
-	Name: 5 stage pipelined Datapath
-	Description: Datapath with 5 stages
-	Refer the microarchitecture in the images folder for reference
-	
-	
+    Name: 5 stage pipelined Datapath
+    Description: Datapath with 5 stages
+    Refer the microarchitecture in the images folder for reference
 */
 
+module datapath(
+    input logic clk, reset,
+    input logic [1:0] ResultSrcW,
+    input logic PCJalSrcE, PCSrcE, ALUSrcAE, 
+    input logic [1:0] ALUSrcBE,
+    input logic RegWriteW,
+    input logic [2:0] ImmSrcD,
+    input logic [3:0] ALUControlE,
+    output logic ZeroE,
+    output logic SignE,
+    output logic [31:0] PCF,
+    input logic [31:0] InstrF,
+    output logic [31:0] InstrD,
+    output logic [31:0] ALUResultM, WriteDataM,
+    input logic [31:0] ReadDataM,
+    input logic [1:0] ForwardAE, ForwardBE,
+    output logic [4:0] Rs1D, Rs2D, Rs1E, Rs2E,
+    output logic [4:0] RdE, RdM, RdW,
+    input logic StallD, StallF, FlushD, FlushE
+);
 
+    logic [31:0] PCD, PCE, ALUResultE, ALUResultW, ReadDataW;
+    logic [31:0] PCNextF, PCPlus4F, PCPlus4D, PCPlus4E, PCPlus4M, PCPlus4W, PCTargetE, BranJumpTargetE;
+    logic [31:0] WriteDataE;
+    logic [31:0] ImmExtD, ImmExtE;
+    logic [31:0] SrcAEfor, SrcAE, SrcBE, RD1D, RD2D, RD1E, RD2E;
+    logic [31:0] ResultW;
+    logic [4:0] RdD; // destination register address
 
-module datapath(input logic clk, reset,
-		input logic [1:0] ResultSrcW,
-		input logic PCJalSrcE, PCSrcE, ALUSrcAE, 
-		input logic [1:0] ALUSrcBE,
-		input logic RegWriteW,
-		input logic [2:0] ImmSrcD,
-		input logic [3:0] ALUControlE,
-		output logic ZeroE,
-		output logic SignE,
-		output logic [31:0] PCF,
-		input logic [31:0] InstrF,
-		output logic [31:0] InstrD,
-		output logic [31:0] ALUResultM, WriteDataM,
-		input logic [31:0] ReadDataM,
-		input logic [1:0] ForwardAE, ForwardBE,
-		output logic [4:0] Rs1D, Rs2D, Rs1E, Rs2E,
-        output logic [4:0] RdE, RdM, RdW,
-		input logic StallD, StallF, FlushD, FlushE);
-
-
-	logic [31:0] PCD, PCE, ALUResultE, ALUResultW, ReadDataW;
-	logic [31:0] PCNextF, PCPlus4F, PCPlus4D, PCPlus4E, PCPlus4M, PCPlus4W, PCTargetE, BranJumpTargetE;
-	logic [31:0] WriteDataE;
-	logic [31:0] ImmExtD, ImmExtE;
-	logic [31:0] SrcAEfor, SrcAE, SrcBE, RD1D, RD2D, RD1E, RD2E;
-	logic [31:0] ResultW;
-	
-	logic [4:0] RdD; // destination register address
-
-	
-	// Fetch Stage
-	
-	mux2 jal_r(PCTargetE, ALUResultE, PCJalSrcE, BranJumpTargetE);
-	mux2 pcmux(PCPlus4F, BranJumpTargetE, PCSrcE, PCNextF);
-	flopenr IF(clk, reset, ~StallF, PCNextF, PCF);
-	adder pcadd4(PCF, 32'd4, PCPlus4F);
-	
-		
-	// Instruction Fetch - Decode Pipeline Register	
-	
-	IF_ID pipreg0 (clk, reset, FlushD, ~StallD, InstrF, PCF, PCPlus4F, InstrD, PCD, PCPlus4D);
-	assign Rs1D = InstrD[19:15];
-	assign Rs2D = InstrD[24:20];		
-	regfile rf (clk, RegWriteW, Rs1D, Rs2D, RdW, ResultW, RD1D, RD2D);	
-	assign RdD = InstrD[11:7];
-	extend ext(InstrD[31:7], ImmSrcD, ImmExtD);
-	
-	// Decode - Execute Pipeline Register	
-	
-	ID_IEx pipreg1 (clk, reset, FlushE, RD1D, RD2D, PCD, Rs1D, Rs2D, RdD, ImmExtD, PCPlus4D, RD1E, RD2E, PCE, Rs1E, Rs2E, RdE, ImmExtE, PCPlus4E);
-	mux3 forwardMuxA (RD1E, ResultW, ALUResultM, ForwardAE, SrcAEfor);
-	mux2 srcamux(SrcAEfor, 32'b0, ALUSrcAE, SrcAE); // for lui
-	mux3 forwardMuxB (RD2E, ResultW, ALUResultM, ForwardBE, WriteDataE);
-	mux3 srcbmux(WriteDataE, ImmExtE, PCTargetE, ALUSrcBE, SrcBE); 
-	adder pcaddbranch(PCE, ImmExtE, PCTargetE); // Next PC for jump and branch instructions
-	alu alu(SrcAE, SrcBE, ALUControlE, ALUResultE, ZeroE, SignE);
-	
-	
-		
-	// Execute - Memory Access Pipeline Register
-	IEx_IMem pipreg2 (clk, reset, ALUResultE, WriteDataE, RdE, PCPlus4E, ALUResultM, WriteDataM, RdM, PCPlus4M);
-	
-		
-	// Memory - Register Write Back Stage
-	IMem_IW pipreg3 (clk, reset, ALUResultM, ReadDataM, RdM, PCPlus4M, ALUResultW, ReadDataW, RdW, PCPlus4W);
-	mux3 resultmux( ALUResultW, ReadDataW, PCPlus4W, ResultSrcW, ResultW);
+    // Fetch Stage
+    mux2 jal_r(PCTargetE, ALUResultE, PCJalSrcE, BranJumpTargetE);
+    mux2 pcmux(PCPlus4F, BranJumpTargetE, PCSrcE, PCNextF);
+    flopenr IF(clk, reset, ~StallF, PCNextF, PCF);
+    adder pcadd4(PCF, 32'd4, PCPlus4F);
+    
+    // Instruction Fetch - Decode Pipeline Register	
+    IF_ID pipreg0 (clk, reset, FlushD, ~StallD, InstrF, PCF, PCPlus4F, InstrD, PCD, PCPlus4D);
+    assign Rs1D = InstrD[19:15];
+    assign Rs2D = InstrD[24:20];
+    regfile u_rf (clk, RegWriteW, Rs1D, Rs2D, RdW, ResultW, RD1D, RD2D);	
+    assign RdD = InstrD[11:7];
+    extend ext(InstrD[31:7], ImmSrcD, ImmExtD);
+    
+    // Decode - Execute Pipeline Register	
+    ID_IEx pipreg1 (clk, reset, FlushE, RD1D, RD2D, PCD, Rs1D, Rs2D, RdD, ImmExtD, PCPlus4D, RD1E, RD2E, PCE, Rs1E, Rs2E, RdE, ImmExtE, PCPlus4E);
+    mux3 forwardMuxA (RD1E, ResultW, ALUResultM, ForwardAE, SrcAEfor);
+    mux2 srcamux(SrcAEfor, 32'b0, ALUSrcAE, SrcAE); // for lui
+    mux3 forwardMuxB (RD2E, ResultW, ALUResultM, ForwardBE, WriteDataE);
+    mux3 srcbmux(WriteDataE, ImmExtE, PCTargetE, ALUSrcBE, SrcBE); 
+    adder pcaddbranch(PCE, ImmExtE, PCTargetE); // Next PC for jump and branch instructions
+    alu alu(SrcAE, SrcBE, ALUControlE, ALUResultE, ZeroE, SignE);
+    
+    // Execute - Memory Access Pipeline Register
+    IEx_IMem pipreg2 (clk, reset, ALUResultE, WriteDataE, RdE, PCPlus4E, ALUResultM, WriteDataM, RdM, PCPlus4M);
+    
+    // Memory - Register Write Back Stage
+    IMem_IW pipreg3 (clk, reset, ALUResultM, ReadDataM, RdM, PCPlus4M, ALUResultW, ReadDataW, RdW, PCPlus4W);
+    mux3 resultmux( ALUResultW, ReadDataW, PCPlus4W, ResultSrcW, ResultW);
 
 endmodule

--- a/source/dmem.sv
+++ b/source/dmem.sv
@@ -1,16 +1,16 @@
 // Name: Data Memory
 
-
-
-module dmem(input logic clk, we, 
-		input logic [31:0] a, wd, 
-		output logic [31:0] rd);
+module dmem(
+	input logic clk, we, 
+	input logic [31:0] addr, wdata, 
+	output logic [31:0] rdata
+);
 		
-	logic [31:0] RAM[63:0]; // 64 x 32 bit memory
-	assign rd = RAM[a[31:2]];     // read operation
+	logic [31:0] RAM [1023:0];
+	assign rdata = RAM[addr[31:2]];
 	
 	// 6 bit address enough to address the 64 locations in data memory
-	
 	always_ff @(posedge clk)
-		if (we) RAM[a[31:2]] <= wd;
+		if (we) RAM[addr[31:2]] <= wdata;
+
 endmodule

--- a/source/hazardunit.sv
+++ b/source/hazardunit.sv
@@ -24,8 +24,6 @@ logic lwStall;
             ForwardAE = 2'b10; // for forwarding ALU Result in Memory Stage
         else if ((Rs1E == RdW) & (RegWriteW) & (Rs1E != 0))
             ForwardAE = 2'b01; // for forwarding WriteBack Stage Result
-                    
-
 
         if ((Rs2E == RdM) & (RegWriteM) & (Rs2E != 0))
             ForwardBE = 2'b10; // for forwarding ALU Result in Memory Stage

--- a/source/imem.sv
+++ b/source/imem.sv
@@ -1,132 +1,120 @@
-/*
-	Name: Instruction Memory
-*/
+// Name: Instruction Memory
 
+module imem(
+    input logic [31:0] addr, 
+    output logic [31:0] rdata
+);
+                
+    logic [7:0] ROM [1023:0];
+    assign rdata = {ROM[addr+3], ROM[addr+2], ROM[addr+1], ROM[addr+0]};
 
-module imem(input logic [31:0] a, output logic [31:0] rd);
-				
-logic [7:0] RAM[128:0]; // 128 x 8 = byte addressable memory with 128 locations
-
-assign rd = {RAM[a+3], RAM[a+2], RAM[a+1], RAM[a+0]};
-
-// follow little-endian: LSB corresponds to lowest order memory address
-initial 
-	begin
-		// Instruction: 00f00093
-		RAM[0] = 8'h93;
-		RAM[1] = 8'h00;
-		RAM[2] = 8'hf0;
-		RAM[3] = 8'h00;
-		// Instruction: 01600113
-		RAM[4] = 8'h13;
-		RAM[5] = 8'h01;
-		RAM[6] = 8'h60;
-		RAM[7] = 8'h01;
-		// Instruction: 002081b3
-		RAM[8] = 8'hb3;
-		RAM[9] = 8'h81;
-		RAM[10] = 8'h20;
-		RAM[11] = 8'h00;
-		// Instruction: 0021e233
-		RAM[12] = 8'h33;
-		RAM[13] = 8'he2;
-		RAM[14] = 8'h21;
-		RAM[15] = 8'h00;
-		// Instruction: 0041c2b3
-		RAM[16] = 8'hb3;
-		RAM[17] = 8'hc2;
-		RAM[18] = 8'h41;
-		RAM[19] = 8'h00;
-		// Instruction: 00428333
-		RAM[20] = 8'h33;
-		RAM[21] = 8'h83;
-		RAM[22] = 8'h42;
-		RAM[23] = 8'h00;
-		// Instruction: 02628863
-		RAM[24] = 8'h63;
-		RAM[25] = 8'h88;
-		RAM[26] = 8'h62;
-		RAM[27] = 8'h02;
-		// Instruction: 0041a233
-		RAM[28] = 8'h33;
-		RAM[29] = 8'ha2;
-		RAM[30] = 8'h41;
-		RAM[31] = 8'h00;
-		// Instruction: 00020463
-		RAM[32] = 8'h63;
-		RAM[33] = 8'h04;
-		RAM[34] = 8'h02;
-		RAM[35] = 8'h00;
-		// Instruction: 00000313
-		RAM[36] = 8'h13;
-		RAM[37] = 8'h03;
-		RAM[38] = 8'h00;
-		RAM[39] = 8'h00;
-		// Instruction: 0032a233
-		RAM[40] = 8'h33;
-		RAM[41] = 8'ha2;
-		RAM[42] = 8'h32;
-		RAM[43] = 8'h00;
-		// Instruction: 00520333
-		RAM[44] = 8'h33;
-		RAM[45] = 8'h03;
-		RAM[46] = 8'h52;
-		RAM[47] = 8'h00;
-		// Instruction: 40118133
-		RAM[48] = 8'h33;
-		RAM[49] = 8'h81;
-		RAM[50] = 8'h11;
-		RAM[51] = 8'h40;
-		// Instruction: 0411aa23
-		RAM[52] = 8'h23;
-		RAM[53] = 8'haa;
-		RAM[54] = 8'h11;
-		RAM[55] = 8'h04;
-		// Instruction: 0541a083
-		RAM[56] = 8'h83;
-		RAM[57] = 8'ha0;
-		RAM[58] = 8'h41;
-		RAM[59] = 8'h05;
-		// Instruction: 00008093
-		RAM[60] = 8'h93;
-		RAM[61] = 8'h80;
-		RAM[62] = 8'h00;
-		RAM[63] = 8'h00;
-		// Instruction: 003103b3
-		RAM[64] = 8'hb3;
-		RAM[65] = 8'h03;
-		RAM[66] = 8'h31;
-		RAM[67] = 8'h00;
-		// Instruction: 004001ef
-		RAM[68] = 8'hef;
-		RAM[69] = 8'h01;
-		RAM[70] = 8'h40;
-		RAM[71] = 8'h00;
-		// Instruction: 00910133
-		RAM[72] = 8'h33;
-		RAM[73] = 8'h01;
-		RAM[74] = 8'h91;
-		RAM[75] = 8'h00;
-		// Instruction: 00100213
-		RAM[76] = 8'h13;
-		RAM[77] = 8'h02;
-		RAM[78] = 8'h10;
-		RAM[79] = 8'h00;
-		// Instruction: 00108063
-		RAM[80] = 8'h63;
-		RAM[81] = 8'h80;
-		RAM[82] = 8'h10;
-		RAM[83] = 8'h00;
-
-
-
-
-
-
-	end
-
-
-
-	//$readmemh("riscvtest.txt",RAM);
-	//assign rd = RAM[a[31:2]]; // word aligned
+    // follow little-endian: LSB corresponds to lowest order memory address
+    initial begin
+        // Instruction: 00f00093
+        ROM[0] = 8'h93;
+        ROM[1] = 8'h00;
+        ROM[2] = 8'hf0;
+        ROM[3] = 8'h00;
+        // Instruction: 01600113
+        ROM[4] = 8'h13;
+        ROM[5] = 8'h01;
+        ROM[6] = 8'h60;
+        ROM[7] = 8'h01;
+        // Instruction: 002081b3
+        ROM[8] = 8'hb3;
+        ROM[9] = 8'h81;
+        ROM[10] = 8'h20;
+        ROM[11] = 8'h00;
+        // Instruction: 0021e233
+        ROM[12] = 8'h33;
+        ROM[13] = 8'he2;
+        ROM[14] = 8'h21;
+        ROM[15] = 8'h00;
+        // Instruction: 0041c2b3
+        ROM[16] = 8'hb3;
+        ROM[17] = 8'hc2;
+        ROM[18] = 8'h41;
+        ROM[19] = 8'h00;
+        // Instruction: 00428333
+        ROM[20] = 8'h33;
+        ROM[21] = 8'h83;
+        ROM[22] = 8'h42;
+        ROM[23] = 8'h00;
+        // Instruction: 02628863
+        ROM[24] = 8'h63;
+        ROM[25] = 8'h88;
+        ROM[26] = 8'h62;
+        ROM[27] = 8'h02;
+        // Instruction: 0041a233
+        ROM[28] = 8'h33;
+        ROM[29] = 8'ha2;
+        ROM[30] = 8'h41;
+        ROM[31] = 8'h00;
+        // Instruction: 00020463
+        ROM[32] = 8'h63;
+        ROM[33] = 8'h04;
+        ROM[34] = 8'h02;
+        ROM[35] = 8'h00;
+        // Instruction: 00000313
+        ROM[36] = 8'h13;
+        ROM[37] = 8'h03;
+        ROM[38] = 8'h00;
+        ROM[39] = 8'h00;
+        // Instruction: 0032a233
+        ROM[40] = 8'h33;
+        ROM[41] = 8'ha2;
+        ROM[42] = 8'h32;
+        ROM[43] = 8'h00;
+        // Instruction: 00520333
+        ROM[44] = 8'h33;
+        ROM[45] = 8'h03;
+        ROM[46] = 8'h52;
+        ROM[47] = 8'h00;
+        // Instruction: 40118133
+        ROM[48] = 8'h33;
+        ROM[49] = 8'h81;
+        ROM[50] = 8'h11;
+        ROM[51] = 8'h40;
+        // Instruction: 0411aa23
+        ROM[52] = 8'h23;
+        ROM[53] = 8'haa;
+        ROM[54] = 8'h11;
+        ROM[55] = 8'h04;
+        // Instruction: 0541a083
+        ROM[56] = 8'h83;
+        ROM[57] = 8'ha0;
+        ROM[58] = 8'h41;
+        ROM[59] = 8'h05;
+        // Instruction: 00008093
+        ROM[60] = 8'h93;
+        ROM[61] = 8'h80;
+        ROM[62] = 8'h00;
+        ROM[63] = 8'h00;
+        // Instruction: 003103b3
+        ROM[64] = 8'hb3;
+        ROM[65] = 8'h03;
+        ROM[66] = 8'h31;
+        ROM[67] = 8'h00;
+        // Instruction: 004001ef
+        ROM[68] = 8'hef;
+        ROM[69] = 8'h01;
+        ROM[70] = 8'h40;
+        ROM[71] = 8'h00;
+        // Instruction: 00910133
+        ROM[72] = 8'h33;
+        ROM[73] = 8'h01;
+        ROM[74] = 8'h91;
+        ROM[75] = 8'h00;
+        // Instruction: 00100213
+        ROM[76] = 8'h13;
+        ROM[77] = 8'h02;
+        ROM[78] = 8'h10;
+        ROM[79] = 8'h00;
+        // Instruction: 00108063
+        ROM[80] = 8'h63;
+        ROM[81] = 8'h80;
+        ROM[82] = 8'h10;
+        ROM[83] = 8'h00;
+    end
+    
 endmodule

--- a/source/maindec.sv
+++ b/source/maindec.sv
@@ -1,39 +1,40 @@
 /***
-	Name: Main Decoder
-	Description: This unit generates the control signals from the 7 bit opcode.
-	Determines the type of instruction
-
-
+    Name: Main Decoder
+    Description: This unit generates the control signals from the 7 bit opcode.
+    Determines the type of instruction
 ***/
 
 module maindec(
-	input logic [6:0] op,
-	output logic [1:0] ResultSrc,
-	output logic MemWrite,
-	output logic Branch, ALUSrcA, 
-	output logic [1:0] ALUSrcB,
-	output logic RegWrite, Jump,
-	output logic [2:0] ImmSrc,
-	output logic [1:0] ALUOp
-	);
-	
+    input  logic [6:0]  op       ,
+    output logic [1:0]  ResultSrc,
+    output logic        MemWrite ,
+    output logic        Branch   , 
+    output logic        ALUSrcA  , 
+    output logic [1:0]  ALUSrcB  ,
+    output logic        RegWrite , 
+    output logic        Jump     ,
+    output logic [2:0]  ImmSrc   ,
+    output logic [1:0]  ALUOp
+);
+    
 logic [13:0] controls;
 assign {RegWrite, ImmSrc, ALUSrcA, ALUSrcB, MemWrite, ResultSrc, Branch, ALUOp, Jump} = controls;
 
 always_comb
-	case(op)
-	// RegWrite_ImmSrc_ALUSrcA_ALUSrcB_MemWrite_ResultSrc_Branch_ALUOp_Jump
-		7'b0000011: controls = 14'b1_000_0_01_0_01_0_00_0; // lw
-		7'b0100011: controls = 14'b0_001_0_01_1_00_0_00_0; // sw
-		7'b0110011: controls = 14'b1_xxx_0_00_0_00_0_10_0; // R–type
-		7'b1100011: controls = 14'b0_010_0_00_0_00_1_01_0; // B-type
-		7'b0010011: controls = 14'b1_000_0_01_0_00_0_10_0; // I–type ALU
-		7'b1101111: controls = 14'b1_011_0_00_0_10_0_00_1; // jal
-		7'b0010111: controls = 14'b1_100_1_10_0_00_0_00_0; // auipc // PC Target for SrcB
-		7'b0110111: controls = 14'b1_100_1_01_0_00_0_00_0; // lui
-		7'b1100111: controls = 14'b1_000_0_01_0_10_0_00_1; // jalr
-		7'b0000000: controls = 14'b0_000_0_00_0_00_0_00_0; // for default values on reset
-		
-		default: 	controls = 14'bx_xxx_x_xx_x_xx_x_xx_x; // instruction not implemented
-	endcase
+    case(op)
+    // RegWrite_ImmSrc_ALUSrcA_ALUSrcB_MemWrite_ResultSrc_Branch_ALUOp_Jump
+        7'b0000011: controls = 14'b1_000_0_01_0_01_0_00_0; // lw
+        7'b0100011: controls = 14'b0_001_0_01_1_00_0_00_0; // sw
+        7'b0110011: controls = 14'b1_xxx_0_00_0_00_0_10_0; // R–type
+        7'b1100011: controls = 14'b0_010_0_00_0_00_1_01_0; // B-type
+        7'b0010011: controls = 14'b1_000_0_01_0_00_0_10_0; // I–type ALU
+        7'b1101111: controls = 14'b1_011_0_00_0_10_0_00_1; // jal
+        7'b0010111: controls = 14'b1_100_1_10_0_00_0_00_0; // auipc // PC Target for SrcB
+        7'b0110111: controls = 14'b1_100_1_01_0_00_0_00_0; // lui
+        7'b1100111: controls = 14'b1_000_0_01_0_10_0_00_1; // jalr
+        7'b0000000: controls = 14'b0_000_0_00_0_00_0_00_0; // for default values on reset
+        
+        default:  controls = 14'bx_xxx_x_xx_x_xx_x_xx_x; // instruction not implemented
+    endcase
+    
 endmodule

--- a/source/mux4.sv
+++ b/source/mux4.sv
@@ -1,5 +1,6 @@
 module mux4 (input logic [31:0] d0, d1, d2, d3, input logic [1:0] s, 
 			output logic [31:0] y);
+
 always_comb begin
 	case(s)
 			2'b00: y = d0;

--- a/source/readme
+++ b/source/readme
@@ -1,1 +1,0 @@
-System Verilog Files

--- a/source/readme.txt
+++ b/source/readme.txt
@@ -1,0 +1,22 @@
+Original Repository: https://github.com/NAvi349/riscv-proc
+
+Modified By: exaithrg
+
+Major Changes:
+
+A critical issue was identified in the handling of Branch instructions (such as BGE, JALR, etc.) within the controller.sv file. Certain signals were being used as operands without undergoing the necessary latch delay through flip-flops, leading to malfunctions in the majority of cases where instructions like BGE and RET were executed. This bug has been rectified by exaithrg.
+
+Original Code in controller.sv:
+assign ZeroOp = ZeroE ^ funct3[0]; // Complements Zero flag for BNE Instruction
+assign SignOp = (SignE ^ funct3[0]) ; //Complements Sign for BGE
+//mux2 BranchSrc (ZeroOp, SignOp, funct3[2], BranchOp); // fix this later
+assign BranchOp = funct3[2] ? (SignOp) : (ZeroOp); 
+assign PCSrcE = (BranchE & BranchOp) | JumpE;
+assign PCJalSrcE = (op == 7'b1100111) ? 1 : 0; // jalr
+
+Revised Code:
+assign ZeroOpE = ZeroE ^ funct3E[0]; // Complements Zero flag for BNE Instruction
+assign SignOpE = (SignE ^ funct3E[0]) ; // Complements Sign for BGE
+assign BranchOpE = funct3E[2] ? (SignOpE) : (ZeroOpE);
+assign PCSrcE = (BranchE & BranchOpE) | JumpE;
+assign PCJalSrcE = (opE == 7'b1100111) ? 1 : 0; // jalr

--- a/source/regfile.sv
+++ b/source/regfile.sv
@@ -6,17 +6,13 @@ module regfile(input logic clk,
 					
 	logic [31:0] rf[31:0]; 	// register file
 	
-
-	
 	// write on falling edge
 	// read on rising edge 
 	
 	// r0 hardwired to 0
 	
-	
 	assign rd1 = (a1 != 0 ) ? rf[a1] : 0;
 	assign rd2 = (a2 != 0 ) ? rf[a2] : 0;
-	
 	
 	always_ff @(negedge clk)
 		if (we3) rf[a3] <= wd3;

--- a/source/riscv_pip_27.sv
+++ b/source/riscv_pip_27.sv
@@ -6,14 +6,14 @@
 
 */
 
-
-
-module riscv_pip_27(input logic clk, reset,
+module riscv_pip_27(
+	input logic clk, reset,
 	output logic [31:0] PCF,
 	input logic [31:0] InstrF,
 	output logic MemWriteM,
 	output logic [31:0] ALUResultM, WriteDataM,
-	input logic [31:0] ReadDataM);
+	input logic [31:0] ReadDataM
+);
 	
 logic ALUSrcAE, RegWriteM, RegWriteW, ZeroE, SignE, PCJalSrcE, PCSrcE;
 logic [1:0] ALUSrcBE;
@@ -26,10 +26,10 @@ logic [4:0] Rs1D, Rs2D, Rs1E, Rs2E;
 logic [4:0] RdE, RdM, RdW;
 logic [1:0] ForwardAE, ForwardBE;
 
-controller c(clk, reset, InstrD[6:0], InstrD[14:12], InstrD[30], ZeroE, SignE, FlushE, ResultSrcE0, ResultSrcW, MemWriteM, PCJalSrcE, PCSrcE, ALUSrcAE, ALUSrcBE, RegWriteM, RegWriteW, ImmSrcD, ALUControlE);
+controller u_controller(clk, reset, InstrD[6:0], InstrD[14:12], InstrD[30], ZeroE, SignE, FlushE, ResultSrcE0, ResultSrcW, MemWriteM, PCJalSrcE, PCSrcE, ALUSrcAE, ALUSrcBE, RegWriteM, RegWriteW, ImmSrcD, ALUControlE);
 
-hazardunit h (Rs1D, Rs2D, Rs1E, Rs2E, RdE, RdM, RdW, RegWriteM, RegWriteW, ResultSrcE0, PCSrcE, ForwardAE, ForwardBE, StallD, StallF, FlushD, FlushE);
+hazardunit u_hazardunit(Rs1D, Rs2D, Rs1E, Rs2E, RdE, RdM, RdW, RegWriteM, RegWriteW, ResultSrcE0, PCSrcE, ForwardAE, ForwardBE, StallD, StallF, FlushD, FlushE);
 
-datapath dp(clk, reset, ResultSrcW, PCJalSrcE, PCSrcE,ALUSrcAE, ALUSrcBE, RegWriteW, ImmSrcD, ALUControlE, ZeroE, SignE, PCF, InstrF, InstrD, ALUResultM, WriteDataM, ReadDataM, ForwardAE, ForwardBE, Rs1D, Rs2D, Rs1E, Rs2E, RdE, RdM, RdW, StallD, StallF, FlushD, FlushE);
+datapath u_datapath(clk, reset, ResultSrcW, PCJalSrcE, PCSrcE,ALUSrcAE, ALUSrcBE, RegWriteW, ImmSrcD, ALUControlE, ZeroE, SignE, PCF, InstrF, InstrD, ALUResultM, WriteDataM, ReadDataM, ForwardAE, ForwardBE, Rs1D, Rs2D, Rs1E, Rs2E, RdE, RdM, RdW, StallD, StallF, FlushD, FlushE);
 
 endmodule

--- a/source/testbench.sv
+++ b/source/testbench.sv
@@ -1,27 +1,16 @@
 module testbench();
-	logic clk, reset, MemWrite;
-	logic [31:0] WriteData, DataAdr;
 
-	top dut(clk, reset, WriteData, DataAdr, MemWrite);
+	logic clk, reset;
+
+	top u_top(clk, reset);
 	
-	initial
-		begin
-			reset <= 1; 
-			# 100; 
-			reset <= 0;
-			
-			$display("Simulation starts!");
-			$monitor("Value of ALU = %d", DataAdr);
-		end
+	initial begin
+		clk = 1;
+		reset <= 1; 
+		# 100; 
+		reset <= 0;
+	end
+
+	always #5 clk = ~clk;
 	
-
-
-	always
-		begin
-			clk <= 1; 
-			# 5; clk <= 0; # 5;
-		end
-		 
-	
-
 endmodule

--- a/source/top.sv
+++ b/source/top.sv
@@ -1,12 +1,38 @@
-module top (input logic 			clk, reset, 
-			output logic [31:0] 	WriteDataM,  DataAdrM, 
-			output logic 			MemWriteM);
-				
-	logic [31:0] PCF, InstrF, ReadDataM;
-	
-// instantiate processor and memories
+module top (
+    input   logic           clk       , 
+    input   logic           reset
+);
 
-	riscv_pip_27 rv( clk, reset, PCF, InstrF, MemWriteM, DataAdrM, WriteDataM, ReadDataM);
-	imem imem(PCF, InstrF);
-	dmem dmem(clk, MemWriteM, DataAdrM, WriteDataM, ReadDataM);
+    logic [31:0]    WriteDataM;
+    logic [31:0]    DataAdrM  ;
+    logic           MemWriteM ;
+    logic [31:0]    PCF       ;
+    logic [31:0]    InstrF    ;
+    logic [31:0]    ReadDataM ;
+    
+    // Only implements 27 instructions in RV32I
+    riscv_pip_27 u_riscv_pip_27(
+        .clk       (clk       ),
+        .reset     (reset     ),
+        .PCF       (PCF       ),
+        .InstrF    (InstrF    ),
+        .MemWriteM (MemWriteM ),
+        .ALUResultM(DataAdrM  ),
+        .WriteDataM(WriteDataM),
+        .ReadDataM (ReadDataM )
+    );
+
+    imem u_imem (
+        .addr(PCF), 
+        .rdata(InstrF)
+    );
+    
+    dmem u_dmem (
+        .clk(clk), 
+        .we(MemWriteM), 
+        .addr(DataAdrM), 
+        .wdata(WriteDataM), 
+        .rdata(ReadDataM)
+    );
+    
 endmodule


### PR DESCRIPTION
**A critical issue was identified in the handling of Branch instructions (such as BGE, JALR, etc.) within the controller.sv file. Certain signals were being used as operands without undergoing the necessary latch delay through flip-flops, leading to malfunctions in the majority of cases where instructions like BGE and RET were executed. This bug has been rectified by exaithrg.**

Original Code in controller.sv:
```verilog
assign ZeroOp = ZeroE ^ funct3[0]; // Complements Zero flag for BNE Instruction
assign SignOp = (SignE ^ funct3[0]) ; //Complements Sign for BGE
//mux2 BranchSrc (ZeroOp, SignOp, funct3[2], BranchOp); // fix this later
assign BranchOp = funct3[2] ? (SignOp) : (ZeroOp); 
assign PCSrcE = (BranchE & BranchOp) | JumpE;
assign PCJalSrcE = (op == 7'b1100111) ? 1 : 0; // jalr
```

Revised Code:
```verilog
assign ZeroOpE = ZeroE ^ funct3E[0]; // Complements Zero flag for BNE Instruction
assign SignOpE = (SignE ^ funct3E[0]) ; // Complements Sign for BGE
assign BranchOpE = funct3E[2] ? (SignOpE) : (ZeroOpE);
assign PCSrcE = (BranchE & BranchOpE) | JumpE;
assign PCJalSrcE = (opE == 7'b1100111) ? 1 : 0; // jalr
```